### PR TITLE
更新到 .NET 9

### DIFF
--- a/src/AnEoT.Tools.MarkdownChecker/AnEoT.Tools.MarkdownChecker.csproj
+++ b/src/AnEoT.Tools.MarkdownChecker/AnEoT.Tools.MarkdownChecker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.37.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Markdig" Version="0.38.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="13.7.0" />
-    <PackageReference Include="YamlDotNet" Version="15.1.2" />
+    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.2.0" />
+    <PackageReference Include="YamlDotNet" Version="16.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AnEoT.Tools.Shared/AnEoT.Tools.Shared.csproj
+++ b/src/AnEoT.Tools.Shared/AnEoT.Tools.Shared.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.1" />
-    <PackageReference Include="YamlDotNet" Version="15.1.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="YamlDotNet" Version="16.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AnEoT.Tools.Shared/AnEoT.Tools.Shared.csproj
+++ b/src/AnEoT.Tools.Shared/AnEoT.Tools.Shared.csproj
@@ -4,10 +4,12 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>True</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.2.0" />
     <PackageReference Include="YamlDotNet" Version="16.2.0" />
   </ItemGroup>
 

--- a/src/AnEoT.Tools.Shared/MarkdownHelper.cs
+++ b/src/AnEoT.Tools.Shared/MarkdownHelper.cs
@@ -1,43 +1,41 @@
-﻿using System.Text;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using AnEoT.Tools.Shared.Models;
-using YamlDotNet.Serialization.NamingConventions;
-using YamlDotNet.Serialization;
 
 namespace AnEoT.Tools.Shared;
 
 public static class MarkdownHelper
 {
+    [RequiresDynamicCode("此方法调用了不支持 IL 裁剪的 YamlDotNet.Serialization.SerializerBuilder.SerializerBuilder()")]
     public static string InsertFrontMatter(string markdown, FrontMatter frontMatter)
     {
         StringBuilder stringBuilder = new(markdown);
-        string yamlHeader = GetYamlFrontMatterString(frontMatter);
+        string yamlHeader = GetYamlHeaderString(frontMatter);
 
         stringBuilder.Insert(0, yamlHeader);
         return stringBuilder.ToString();
     }
-    
+
+    [RequiresDynamicCode("此方法调用了不支持 IL 裁剪的 YamlDotNet.Serialization.SerializerBuilder.SerializerBuilder()")]
     public static StringBuilder InsertFrontMatter(StringBuilder markdownStringBuilder, FrontMatter frontMatter)
     {
-        string yamlHeader = GetYamlFrontMatterString(frontMatter);
+        string yamlHeader = GetYamlHeaderString(frontMatter);
 
         markdownStringBuilder.Insert(0, yamlHeader);
         return markdownStringBuilder;
     }
 
-    private static string GetYamlFrontMatterString(FrontMatter frontMatter)
+    [RequiresDynamicCode("此方法调用了不支持 IL 裁剪的 YamlDotNet.Serialization.SerializerBuilder.SerializerBuilder()")]
+    public static string GetYamlHeaderString(FrontMatter frontMatter)
     {
-        ISerializer serializer = new SerializerBuilder()
-                        .WithIndentedSequences()
-                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                        .Build();
-        string yamlString = serializer.Serialize(frontMatter).Trim();
-        string yamlHeader = $"""
-                ---
-                {yamlString}
-                ---
+        string yamlString = frontMatter.GetYamlString();
 
+        StringBuilder stringBuilder = new(200);
+        stringBuilder.AppendLine("---");
+        stringBuilder.AppendLine(yamlString);
+        stringBuilder.AppendLine("---");
+        stringBuilder.AppendLine();
 
-                """;
-        return yamlHeader;
+        return stringBuilder.ToString();
     }
 }

--- a/src/AnEoT.Tools.Shared/Models/FrontMatter.cs
+++ b/src/AnEoT.Tools.Shared/Models/FrontMatter.cs
@@ -1,4 +1,9 @@
 ﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using AnEoT.Tools.Shared.StaticContexts;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AnEoT.Tools.Shared.Models;
 
@@ -11,4 +16,124 @@ public readonly record struct FrontMatter(
     [property: YamlMember(Order = 6, DefaultValuesHandling = DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitEmptyCollections)] IEnumerable<string>? Category,
     [property: YamlMember(Order = 7, DefaultValuesHandling = DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitEmptyCollections)] IEnumerable<string>? Tag,
     [property: YamlMember(Order = 9)] int Order,
-    [property: YamlMember(Order = 8, DefaultValuesHandling = DefaultValuesHandling.OmitNull)] string? Description);
+    [property: YamlMember(Order = 8, DefaultValuesHandling = DefaultValuesHandling.OmitNull)] string? Description)
+{
+    [RequiresDynamicCode("此方法调用了不支持 IL 裁剪的 YamlDotNet.Serialization.SerializerBuilder.SerializerBuilder()")]
+    public string GetYamlString()
+    {
+        ISerializer serializer = new SerializerBuilder()
+                        .WithIndentedSequences()
+                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                        .Build();
+        //ISerializer serializer = new StaticSerializerBuilder(new FrontMatterStaticContext())
+        //                .WithIndentedSequences()
+        //                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        //                .Build();
+        string yamlString = serializer.Serialize(this).Trim();
+        return yamlString;
+    }
+
+    [RequiresDynamicCode("此方法调用了不支持 IL 裁剪的 YamlDotNet.Serialization.DeserializerBuilder.DeserializerBuilder()")]
+    public static bool TryParse(string yaml, out FrontMatter result)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            result = default;
+            return false;
+        }
+
+        try
+        {
+            StringReader input = new(yaml);
+            Parser yamlParser = new(input);
+            yamlParser.Consume<StreamStart>();
+            yamlParser.Consume<DocumentStart>();
+
+            IDeserializer yamlDes = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            //IDeserializer yamlDes = new StaticDeserializerBuilder(new FrontMatterStaticContext())
+            //    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            //    .Build();
+            result = yamlDes.Deserialize<FrontMatter>(yamlParser);
+            yamlParser.Consume<DocumentEnd>();
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+
+        return true;
+    }
+}
+
+internal class ClassFrontMatter
+{
+    [YamlMember(Order = 2)]
+    public string Title { get; set; } = string.Empty;
+
+    [YamlMember(Order = 3, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? ShortTitle { get; set; }
+
+    [YamlMember(Order = 1, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string Icon { get; set; } = string.Empty;
+
+    [YamlMember(Order = 4, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? Author { get; set; }
+
+    [YamlMember(Order = 5, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? Date { get; set; }
+
+    [YamlMember(Order = 6, DefaultValuesHandling = DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitEmptyCollections)]
+    public IEnumerable<string>? Category { get; set; }
+
+    [YamlMember(Order = 7, DefaultValuesHandling = DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitEmptyCollections)]
+    public IEnumerable<string>? Tag { get; set; }
+
+    [YamlMember(Order = 9)]
+    public int Order { get; set; }
+
+    [YamlMember(Order = 8, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? Description { get; set; }
+
+    public string GetYamlString()
+    {
+        ISerializer serializer = new StaticSerializerBuilder(new FrontMatterStaticContext())
+                        .WithIndentedSequences()
+                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                        .Build();
+        string yamlString = serializer.Serialize(this).Trim();
+        return yamlString;
+    }
+
+    public static bool TryParse(string yaml, out FrontMatter? result)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            result = default;
+            return false;
+        }
+
+        try
+        {
+            StringReader input = new(yaml);
+            Parser yamlParser = new(input);
+            yamlParser.Consume<StreamStart>();
+            yamlParser.Consume<DocumentStart>();
+
+            IDeserializer yamlDes = new StaticDeserializerBuilder(new FrontMatterStaticContext())
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            result = yamlDes.Deserialize<FrontMatter>(yamlParser);
+            yamlParser.Consume<DocumentEnd>();
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/AnEoT.Tools.Shared/StaticContexts/FrontMatterStaticContext.cs
+++ b/src/AnEoT.Tools.Shared/StaticContexts/FrontMatterStaticContext.cs
@@ -1,0 +1,10 @@
+﻿using YamlDotNet.Serialization;
+using AnEoT.Tools.Shared.Models;
+
+namespace AnEoT.Tools.Shared.StaticContexts;
+
+[YamlStaticContext]
+[YamlSerializable(typeof(FrontMatter))]
+public partial class FrontMatterStaticContext : StaticContext
+{
+}

--- a/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
+++ b/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="RootDescriptor.xml" CopyToOutputDirectory="Always"/>
+    <None Update="RootDescriptor.xml" CopyToOutputDirectory="Always" />
     <TrimmerRootDescriptor Include="RootDescriptor.xml" />
   </ItemGroup>
 
@@ -65,6 +65,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.1.240916" />

--- a/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
+++ b/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
@@ -13,7 +13,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DefaultLanguage>zh-CN</DefaultLanguage>
-    <PackageCertificateThumbprint>DDB65A16ADD7329008B9ACC55F0B4C6AF71848B5</PackageCertificateThumbprint>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
@@ -33,6 +32,16 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <EnableAotAnalyzer>True</EnableAotAnalyzer>
   </PropertyGroup>
+
+  <PropertyGroup>
+      <PackageCertificateThumbprint Condition="$(Configuration) != 'Release'">70211FC3C97E403131B9A07F4D5F11FB3C59A2A4</PackageCertificateThumbprint>
+      <PackageCertificateThumbprint Condition="$(Configuration) == 'Release'">DDB65A16ADD7329008B9ACC55F0B4C6AF71848B5</PackageCertificateThumbprint>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AppxManifest Include="Package.appxmanifest" Condition="$(Configuration) == 'Release'" SubType="Designer" />
+    <AppxManifest Include="Package-Debug.appxmanifest" Condition="$(Configuration) != 'Release'" SubType="Designer" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="RootDescriptor.xml" CopyToOutputDirectory="Always" />
@@ -80,6 +89,7 @@
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="WinUIEx" Version="2.5.0" />
+    <ProjectReference Include="..\AnEoT.Tools.Shared\AnEoT.Tools.Shared.csproj" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 
@@ -90,9 +100,6 @@
   -->
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AnEoT.Tools.Shared\AnEoT.Tools.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Microsoft.UI.Xaml" />

--- a/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
+++ b/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
@@ -50,17 +50,7 @@
 
   <ItemGroup>
     <None Remove="AppPackages\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="Controls\Eod.xaml" />
-    <None Remove="Controls\FakeAds.xaml" />
-    <None Remove="Views\ContentPage.xaml" />
-    <None Remove="Views\EditorsInfoDialog.xaml" />
-    <None Remove="Views\FrontMatterDialog.xaml" />
-    <None Remove="Views\InsertStyleDialog.xaml" />
-    <None Remove="Views\MarkdownEditPage.xaml" />
-    <None Remove="Views\MarkdownEditWindow.xaml" />
-    <None Remove="Views\NewAssetFolderDialog.xaml" />
+    <PRIResource Remove="AppPackages\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -70,6 +60,24 @@
     <Content Include="Assets\Square44x44Logo.scale-200.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.UI.Xaml" />
+    <Using Include="Microsoft.UI.Xaml.Data" />
+    <Using Include="Microsoft.UI.Xaml.Input" />
+    <Using Include="Microsoft.UI.Xaml.Media" />
+    <Using Include="Microsoft.UI.Xaml.Navigation" />
+    <Using Include="Microsoft.UI.Xaml.Controls" />
+    <Using Include="Microsoft.UI.Xaml.Controls.Primitives" />
+    <Using Include="Windows.Foundation" />
+    <Using Include="Windows.Foundation.Collections" />
+    <Using Include="System.Runtime.InteropServices.WindowsRuntime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Controls\*.xaml" />
+    <None Remove="Views\*.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -101,53 +109,6 @@
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
   </ItemGroup>
-  <ItemGroup>
-    <Using Include="Microsoft.UI.Xaml" />
-    <Using Include="Microsoft.UI.Xaml.Data" />
-    <Using Include="Microsoft.UI.Xaml.Input" />
-    <Using Include="Microsoft.UI.Xaml.Media" />
-    <Using Include="Microsoft.UI.Xaml.Navigation" />
-    <Using Include="Microsoft.UI.Xaml.Controls" />
-    <Using Include="Microsoft.UI.Xaml.Controls.Primitives" />
-    <Using Include="Windows.Foundation" />
-    <Using Include="Windows.Foundation.Collections" />
-    <Using Include="System.Runtime.InteropServices.WindowsRuntime" />
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Controls\FakeAds.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\EditorsInfoDialog.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\FrontMatterDialog.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\MarkdownEditPage.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\MarkdownEditWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\ContentPage.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Controls\Eod.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
 
   <!-- 
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
@@ -157,18 +118,5 @@
   <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
-  <ItemGroup>
-    <PRIResource Remove="AppPackages\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\NewAssetFolderDialog.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\InsertStyleDialog.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
 </Project>
  

--- a/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
+++ b/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
@@ -31,7 +31,14 @@
     <Title>AnEoT Volume Creator</Title>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <EnableAotAnalyzer>True</EnableAotAnalyzer>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="RootDescriptor.xml" CopyToOutputDirectory="Always"/>
+    <TrimmerRootDescriptor Include="RootDescriptor.xml" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Remove="AppPackages\**" />
   </ItemGroup>
@@ -156,3 +163,4 @@
     </Page>
   </ItemGroup>
 </Project>
+ 

--- a/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
+++ b/src/AnEoT.Tools.VolumeCreator/AnEoT.Tools.VolumeCreator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>AnEoT.Tools.VolumeCreator</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -26,6 +26,11 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
+    <Authors>Baka632</Authors>
+    <Company>Terra Creator Association</Company>
+    <Title>AnEoT Volume Creator</Title>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="AppPackages\**" />
@@ -52,21 +57,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.240109" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
-    <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="Markdig" Version="0.38.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240802000" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="WinUIEx" Version="2.3.4" />
+    <PackageReference Include="WinUIEx" Version="2.5.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/src/AnEoT.Tools.VolumeCreator/App.xaml.cs
+++ b/src/AnEoT.Tools.VolumeCreator/App.xaml.cs
@@ -19,7 +19,20 @@ public partial class App : Application
     /// </summary>
     public static string AppVersion => $"{Package.Current.Id.Version.Major}.{Package.Current.Id.Version.Minor}.{Package.Current.Id.Version.Build}.{Package.Current.Id.Version.Revision}";
 
+    public static string AppName { get; }
+
     public Window Window { get; private set; }
+
+    static App()
+    {
+        DateTimeOffset now = DateTimeOffset.Now;
+        AppName = now switch
+        {
+            { Month: 1, Day: 4 } => $"{Package.Current.DisplayName} - 尤里卡生日快乐！",
+            { Month: 5, Day: 17 } => $"{Package.Current.DisplayName} - 回归线生日快乐！",
+            _ => Package.Current.DisplayName
+        };
+    }
 
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
@@ -71,7 +84,7 @@ public partial class App : Application
         MainWindow mainWindow = new()
         {
             ExtendsContentIntoTitleBar = true,
-            Title = "AnEoT Volume Creator",
+            Title = AppName,
         };
         Window = mainWindow;
 

--- a/src/AnEoT.Tools.VolumeCreator/CommonValues.cs
+++ b/src/AnEoT.Tools.VolumeCreator/CommonValues.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Text.Unicode;
+using AnEoT.Tools.VolumeCreator.Models;
 using Markdig;
 
 namespace AnEoT.Tools.VolumeCreator;
@@ -17,14 +19,22 @@ public class CommonValues
             .UseYamlFrontMatter()
             .Build();
 
-    public static readonly JsonSerializerOptions DefaultJsonSerializerOption = new()
+    public static readonly JsonSerializerOptions DefaultJsonSerializerOption = CreateJsonSerializerOption(null);
+
+    public static JsonSerializerOptions CreateJsonSerializerOption(IJsonTypeInfoResolver? typeInfoResolver)
     {
-        WriteIndented = true,
-        Converters =
+        return new()
         {
-            new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
-        },
-        ReferenceHandler = ReferenceHandler.Preserve,
-        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-    };
+            WriteIndented = true,
+            Converters =
+            {
+                new JsonStringEnumConverter<PredefinedCategory>(JsonNamingPolicy.CamelCase),
+                new JsonStringEnumConverter<MarkdownWrapperType>(JsonNamingPolicy.CamelCase),
+                new JsonStringEnumConverter<AssetNodeType>(JsonNamingPolicy.CamelCase),
+            },
+            TypeInfoResolver = typeInfoResolver,
+            ReferenceHandler = ReferenceHandler.Preserve,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+        };
+    }
 }

--- a/src/AnEoT.Tools.VolumeCreator/Helpers/AssetNodeDataTemplateSelector.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Helpers/AssetNodeDataTemplateSelector.cs
@@ -2,7 +2,7 @@
 
 namespace AnEoT.Tools.VolumeCreator.Helpers;
 
-public sealed class AssetNodeDataTemplateSelector : DataTemplateSelector
+public sealed partial class AssetNodeDataTemplateSelector : DataTemplateSelector
 {
     public DataTemplate? FileTemplate { get; set; }
     public DataTemplate? FolderTemplate { get; set; }
@@ -13,8 +13,8 @@ public sealed class AssetNodeDataTemplateSelector : DataTemplateSelector
 
         return model.Type switch
         {
-            ImageListNodeType.File => FileTemplate!,
-            ImageListNodeType.Folder => FolderTemplate!,
+            AssetNodeType.File => FileTemplate!,
+            AssetNodeType.Folder => FolderTemplate!,
             _ => throw new NotImplementedException(),
         };
     }

--- a/src/AnEoT.Tools.VolumeCreator/Helpers/Converters/Int32ToStringConverter.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Helpers/Converters/Int32ToStringConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace AnEoT.Tools.VolumeCreator.Helpers.Converters;
 
-public sealed class Int32ToStringConverter : IValueConverter
+public sealed partial class Int32ToStringConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/AnEoT.Tools.VolumeCreator/Helpers/Converters/MarkdownWrapperTypeToStringConverter.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Helpers/Converters/MarkdownWrapperTypeToStringConverter.cs
@@ -3,7 +3,7 @@ using AnEoT.Tools.VolumeCreator.Models;
 
 namespace AnEoT.Tools.VolumeCreator.Helpers.Converters;
 
-public sealed class MarkdownWrapperTypeToStringConverter : IValueConverter
+public sealed partial class MarkdownWrapperTypeToStringConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/AnEoT.Tools.VolumeCreator/Helpers/Converters/PredefinedCategoryWrapperToStringConverter.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Helpers/Converters/PredefinedCategoryWrapperToStringConverter.cs
@@ -2,7 +2,7 @@
 
 namespace AnEoT.Tools.VolumeCreator.Helpers.Converters;
 
-public sealed class PredefinedCategoryWrapperToStringConverter : IValueConverter
+public sealed partial class PredefinedCategoryWrapperToStringConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/AnEoT.Tools.VolumeCreator/Helpers/FakeAdHelper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Helpers/FakeAdHelper.cs
@@ -61,7 +61,8 @@ public static class FakeAdHelper
     {
         StorageFile adJsonFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/fake-ads/ads.json"));
         using Stream utf8Json = await adJsonFile.OpenStreamForReadAsync();
-        Dictionary<string, FakeAdConfiguration> adConfig = await JsonSerializer.DeserializeAsync<Dictionary<string, FakeAdConfiguration>>(utf8Json) ?? throw new FileNotFoundException("未能找到配置「泰拉广告」的 JSON 文件。");
+        Dictionary<string, FakeAdConfiguration> adConfig = await JsonSerializer.DeserializeAsync(utf8Json, StringFakeAdConfigContext.Default.DictionaryStringFakeAdConfiguration)
+            ?? throw new FileNotFoundException("未能找到配置「泰拉广告」的 JSON 文件。");
 
         return adConfig;
     }

--- a/src/AnEoT.Tools.VolumeCreator/Models/AssetNode.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/AssetNode.cs
@@ -29,7 +29,7 @@ public abstract class AssetNode : INotifyPropertyChanged
 
     public AssetNode? Parent { get; set; } = null;
 
-    public ImageListNodeType Type { get; set; }
+    public AssetNodeType Type { get; set; }
 
     public override string ToString() => DisplayName;
 
@@ -43,7 +43,7 @@ public abstract class AssetNode : INotifyPropertyChanged
     }
 }
 
-public sealed class FileNode : AssetNode
+public sealed partial class FileNode : AssetNode
 {
     private string _filePath = string.Empty;
 
@@ -88,7 +88,7 @@ public sealed class FileNode : AssetNode
 
     public FileNode()
     {
-        Type = ImageListNodeType.File;
+        Type = AssetNodeType.File;
     }
 
     public void EnsurePathExist()
@@ -97,22 +97,22 @@ public sealed class FileNode : AssetNode
     }
 }
 
-public sealed class FolderNode : AssetNode
+public sealed partial class FolderNode : AssetNode
 {
     public FolderNode(string folderName, AssetNode? parent)
     {
         DisplayName = folderName;
-        Type = ImageListNodeType.Folder;
+        Type = AssetNodeType.Folder;
         Parent = parent;
     }
 
     public FolderNode()
     {
-        Type = ImageListNodeType.Folder;
+        Type = AssetNodeType.Folder;
     }
 }
 
-public enum ImageListNodeType
+public enum AssetNodeType
 {
     /// <summary>
     /// 文件节点

--- a/src/AnEoT.Tools.VolumeCreator/Models/MarkdownWrapper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/MarkdownWrapper.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace AnEoT.Tools.VolumeCreator.Models;
 
-public sealed class MarkdownWrapper(string displayName, string markdown, MarkdownWrapperType type = default, string outputTitle = "", PredefinedCategory? categoryInIndexPage = null) : INotifyPropertyChanged
+public sealed partial class MarkdownWrapper(string displayName, string markdown, MarkdownWrapperType type = default, string outputTitle = "", PredefinedCategory? categoryInIndexPage = null) : INotifyPropertyChanged
 {
     [JsonIgnore]
     public static readonly List<MarkdownWrapperType> AvailableTypes =

--- a/src/AnEoT.Tools.VolumeCreator/Models/ProjectPackage.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/ProjectPackage.cs
@@ -390,6 +390,8 @@ public sealed partial class ProjectPackage : IDisposable, IAsyncDisposable
         }
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "已经保留了必需的类型信息")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "已经保留了必需的类型信息")]
     private static async Task InitializePackageFor<T>(ProjectPackage package, string packageFileName, Action<T?> operationForPackage, string parseErrorMessage, bool required = false, string fileNotFoundErrorMessage = "")
     {
         if (package.TryGetEntryStream(packageFileName, out Stream? entryStream))
@@ -413,6 +415,8 @@ public sealed partial class ProjectPackage : IDisposable, IAsyncDisposable
         }
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "已经保留了必需的类型信息")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "已经保留了必需的类型信息")]
     private async Task SavePackageFor<T>(string entryName, T value)
     {
         if (value is null || value.Equals(default))

--- a/src/AnEoT.Tools.VolumeCreator/Models/ProjectPackage.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/ProjectPackage.cs
@@ -58,7 +58,15 @@ public sealed partial class ProjectPackage : IDisposable, IAsyncDisposable
             stream.Seek(0, SeekOrigin.Begin);
         }
 
-        zipArchive = new ZipArchive(stream, ZipArchiveMode.Update);
+        try
+        {
+            zipArchive = new ZipArchive(stream, ZipArchiveMode.Update);
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -163,7 +171,6 @@ public sealed partial class ProjectPackage : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            package?.zipArchive?.Dispose();
             throw new InvalidDataException("工程文件无效，请查阅内部异常以获取更多信息。", ex);
         }
     }

--- a/src/AnEoT.Tools.VolumeCreator/Models/Resources/IVolumeResourcesHelper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/Resources/IVolumeResourcesHelper.cs
@@ -3,7 +3,7 @@ using Windows.Storage;
 
 namespace AnEoT.Tools.VolumeCreator.Models.Resources;
 
-public interface IVoulmeResourcesHelper
+public interface IVolumeResourcesHelper
 {
     public bool ConvertWebP { get; set; }
     public bool HasCover { get; }

--- a/src/AnEoT.Tools.VolumeCreator/Models/Resources/MemoryResourcesHelper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/Resources/MemoryResourcesHelper.cs
@@ -67,11 +67,11 @@ internal sealed class MemoryResourcesHelper : IVoulmeResourcesHelper
 
     private async Task CopyContentRecursively(AssetNode node, StorageFolder rootFolder)
     {
-        if (node.Type == ImageListNodeType.Folder)
+        if (node.Type == AssetNodeType.Folder)
         {
             foreach (AssetNode item in node.Children)
             {
-                if (item.Type == ImageListNodeType.Folder)
+                if (item.Type == AssetNodeType.Folder)
                 {
                     if (item.Children.Count > 0)
                     {
@@ -83,13 +83,13 @@ internal sealed class MemoryResourcesHelper : IVoulmeResourcesHelper
                         }
                     }
                 }
-                else if (item.Type == ImageListNodeType.File && item is FileNode fileNode && File.Exists(fileNode.FilePath))
+                else if (item.Type == AssetNodeType.File && item is FileNode fileNode && File.Exists(fileNode.FilePath))
                 {
                     await SaveFileNode(fileNode, rootFolder);
                 }
             }
         }
-        else if (node.Type == ImageListNodeType.File && node is FileNode fileNode && File.Exists(fileNode.FilePath))
+        else if (node.Type == AssetNodeType.File && node is FileNode fileNode && File.Exists(fileNode.FilePath))
         {
             await SaveFileNode(fileNode, rootFolder);
         }

--- a/src/AnEoT.Tools.VolumeCreator/Models/Resources/MemoryResourcesHelper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/Resources/MemoryResourcesHelper.cs
@@ -6,7 +6,7 @@ using ImageSharpImage = SixLabors.ImageSharp.Image;
 
 namespace AnEoT.Tools.VolumeCreator.Models.Resources;
 
-internal sealed class MemoryResourcesHelper : IVoulmeResourcesHelper
+internal sealed class MemoryResourcesHelper : IVolumeResourcesHelper
 {
     private StorageFile? coverFile;
 

--- a/src/AnEoT.Tools.VolumeCreator/Models/Resources/ProjectPackageResourcesHelper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/Resources/ProjectPackageResourcesHelper.cs
@@ -6,7 +6,7 @@ using ImageSharpImage = SixLabors.ImageSharp.Image;
 
 namespace AnEoT.Tools.VolumeCreator.Models.Resources;
 
-internal sealed partial class ProjectPackageResourcesHelper(ProjectPackage projectPackage) : IVoulmeResourcesHelper, IDisposable, IAsyncDisposable
+internal sealed partial class ProjectPackageResourcesHelper(ProjectPackage projectPackage) : IVolumeResourcesHelper, IDisposable, IAsyncDisposable
 {
     public bool ConvertWebP
     {

--- a/src/AnEoT.Tools.VolumeCreator/Models/Resources/ProjectPackageResourcesHelper.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/Resources/ProjectPackageResourcesHelper.cs
@@ -6,7 +6,7 @@ using ImageSharpImage = SixLabors.ImageSharp.Image;
 
 namespace AnEoT.Tools.VolumeCreator.Models.Resources;
 
-internal sealed class ProjectPackageResourcesHelper(ProjectPackage projectPackage) : IVoulmeResourcesHelper, IDisposable, IAsyncDisposable
+internal sealed partial class ProjectPackageResourcesHelper(ProjectPackage projectPackage) : IVoulmeResourcesHelper, IDisposable, IAsyncDisposable
 {
     public bool ConvertWebP
     {
@@ -41,11 +41,11 @@ internal sealed class ProjectPackageResourcesHelper(ProjectPackage projectPackag
 
     private async Task ExportAssetsCore(AssetNode node, StorageFolder outputFolder)
     {
-        if (node.Type == ImageListNodeType.Folder)
+        if (node.Type == AssetNodeType.Folder)
         {
             foreach (AssetNode item in node.Children)
             {
-                if (item.Type == ImageListNodeType.Folder)
+                if (item.Type == AssetNodeType.Folder)
                 {
                     if (item.Children.Count > 0)
                     {
@@ -57,13 +57,13 @@ internal sealed class ProjectPackageResourcesHelper(ProjectPackage projectPackag
                         }
                     }
                 }
-                else if (item.Type == ImageListNodeType.File && item is FileNode fileNode)
+                else if (item.Type == AssetNodeType.File && item is FileNode fileNode)
                 {
                     await SaveFileNode(fileNode, outputFolder);
                 }
             }
         }
-        else if (node.Type == ImageListNodeType.File && node is FileNode fileNode)
+        else if (node.Type == AssetNodeType.File && node is FileNode fileNode)
         {
             await SaveFileNode(fileNode, outputFolder);
         }

--- a/src/AnEoT.Tools.VolumeCreator/Models/SerializerContexts.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/SerializerContexts.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AnEoT.Tools.VolumeCreator.Models;
+
+[JsonSerializable(typeof(Dictionary<string, FakeAdConfiguration>))]
+public partial class StringFakeAdConfigContext : JsonSerializerContext
+{
+}

--- a/src/AnEoT.Tools.VolumeCreator/Models/StringView.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Models/StringView.cs
@@ -6,7 +6,7 @@ namespace AnEoT.Tools.VolumeCreator.Models;
 /// <summary>
 /// 用于支持双向数据绑定的字符串包装类
 /// </summary>
-public sealed class StringView : INotifyPropertyChanged, IEquatable<StringView?>
+public sealed partial class StringView : INotifyPropertyChanged, IEquatable<StringView?>
 {
     public event PropertyChangedEventHandler? PropertyChanged;
     private string _StringContent = string.Empty;

--- a/src/AnEoT.Tools.VolumeCreator/Package-Debug.appxmanifest
+++ b/src/AnEoT.Tools.VolumeCreator/Package-Debug.appxmanifest
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+
+  <Identity
+    Name="Baka632.AnEoTVolumeCreator.Debug"
+    Publisher="CN=Baka632"
+    Version="1.3.0.0" />
+
+  <mp:PhoneIdentity PhoneProductId="2f43e7bc-239a-4386-ba28-b7509fcd331a" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
+
+  <Properties>
+    <DisplayName>AnEoT Volume Creator (调试)</DisplayName>
+    <PublisherDisplayName>Baka632</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="AnEoT Volume Creator（调试）"
+        Description="Volume Creator Utility for AnEoT"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"  Square71x71Logo="Assets\SmallTile.png" Square310x310Logo="Assets\LargeTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo"/>
+            <uap:ShowOn Tile="wide310x150Logo"/>
+            <uap:ShowOn Tile="square310x310Logo"/>
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile >
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="aneot-volume-project">
+            <uap:SupportedFileTypes>
+              <uap:FileType ContentType="application/json">.aneot-proj</uap:FileType>
+            </uap:SupportedFileTypes>
+            <uap:DisplayName>《回归线》网页版工程文件</uap:DisplayName>
+            <uap:EditFlags OpenIsSafe="true"/>
+            <uap:Logo>Assets\FileExtension.png</uap:Logo>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/src/AnEoT.Tools.VolumeCreator/RootDescriptor.xml
+++ b/src/AnEoT.Tools.VolumeCreator/RootDescriptor.xml
@@ -1,0 +1,5 @@
+﻿<!-- 不要裁剪我😭 -->
+<linker>
+    <assembly fullname="AnEoT.Tools.VolumeCreator" preserve="all"/>
+    <assembly fullname="CommunityToolkit.WinUI.Controls.SettingsControls" preserve="all"/>
+</linker>

--- a/src/AnEoT.Tools.VolumeCreator/ViewModels/ContentPageViewModel.Properties.cs
+++ b/src/AnEoT.Tools.VolumeCreator/ViewModels/ContentPageViewModel.Properties.cs
@@ -18,7 +18,7 @@ partial class ContentPageViewModel
     public bool ShowNotifyGenerateIndex => IndexMarkdown.Count <= 0;
     [Required]
     [CustomValidation(typeof(ContentPageViewModel), nameof(ValidateResourcesHelper))]
-    public IVoulmeResourcesHelper ResourcesHelper
+    public IVolumeResourcesHelper ResourcesHelper
     {
         get => resourcesHelper;
         set
@@ -27,9 +27,9 @@ partial class ContentPageViewModel
             ResourcesHelperForValidation = value;
         }
     }
-    public static IVoulmeResourcesHelper ResourcesHelperForValidation { get; set; } = new MemoryResourcesHelper();
+    public static IVolumeResourcesHelper ResourcesHelperForValidation { get; set; } = new MemoryResourcesHelper();
 
-    private IVoulmeResourcesHelper resourcesHelper = new MemoryResourcesHelper();
+    private IVolumeResourcesHelper resourcesHelper = new MemoryResourcesHelper();
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsVolumeCoverNotExist))]
@@ -147,7 +147,7 @@ partial class ContentPageViewModel
     }
     #endregion
 
-    public static ValidationResult ValidateResourcesHelper(IVoulmeResourcesHelper helper)
+    public static ValidationResult ValidateResourcesHelper(IVolumeResourcesHelper helper)
     {
         if (!helper.HasCover)
         {

--- a/src/AnEoT.Tools.VolumeCreator/ViewModels/ContentPageViewModel.cs
+++ b/src/AnEoT.Tools.VolumeCreator/ViewModels/ContentPageViewModel.cs
@@ -16,10 +16,6 @@ using Markdig;
 using Markdig.Syntax;
 using Markdig.Extensions.Yaml;
 using System.Diagnostics.CodeAnalysis;
-using YamlDotNet.Core;
-using YamlDotNet.Serialization.NamingConventions;
-using YamlDotNet.Serialization;
-using YamlDotNet.Core.Events;
 using AnEoT.Tools.Shared.Models;
 using SixLabors.ImageSharp.Processing;
 using AnEoT.Tools.VolumeCreator.Models.Resources;
@@ -138,6 +134,7 @@ public sealed partial class ContentPageViewModel : ObservableValidator
         await LoadProject(file);
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "已经保留了必需的类型信息")]
     public async Task LoadProject(StorageFile? file)
     {
         if (file is null)
@@ -735,7 +732,7 @@ public sealed partial class ContentPageViewModel : ObservableValidator
 
         string yaml = markdown.Substring(yamlBlock.Span.Start, yamlBlock.Span.Length);
 
-        if (TryReadYaml(yaml, out FrontMatter result))
+        if (FrontMatter.TryParse(yaml, out FrontMatter result))
         {
             return result.Title;
         }
@@ -864,38 +861,5 @@ public sealed partial class ContentPageViewModel : ObservableValidator
         TeachingTipIconSource = icon;
 
         IsShowTeachingTip = true;
-    }
-
-    [RequiresDynamicCode("此方法调用了不支持 IL 裁剪的 YamlDotNet.Serialization.DeserializerBuilder.DeserializerBuilder()")]
-    public static bool TryReadYaml<T>(string yaml, [MaybeNullWhen(false)] out T result)
-    {
-        if (string.IsNullOrWhiteSpace(yaml))
-        {
-            result = default;
-            return false;
-        }
-
-        T obj;
-        try
-        {
-            StringReader input = new(yaml);
-            Parser yamlParser = new(input);
-            yamlParser.Consume<StreamStart>();
-            yamlParser.Consume<DocumentStart>();
-
-            IDeserializer yamlDes = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            obj = yamlDes.Deserialize<T>(yamlParser);
-            yamlParser.Consume<DocumentEnd>();
-        }
-        catch
-        {
-            result = default;
-            return false;
-        }
-
-        result = obj;
-        return true;
     }
 }

--- a/src/AnEoT.Tools.VolumeCreator/ViewModels/MarkdownEditViewModel.cs
+++ b/src/AnEoT.Tools.VolumeCreator/ViewModels/MarkdownEditViewModel.cs
@@ -1,13 +1,12 @@
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
-using AnEoT.Tools.VolumeCreator.Models;
 using AnEoT.Tools.VolumeCreator.Views;
-using AnEoT.Tools.Shared.Models;
-using YamlDotNet.Serialization.NamingConventions;
-using YamlDotNet.Serialization;
+using AnEoT.Tools.VolumeCreator.Models;
+using AnEoT.Tools.VolumeCreator.Models.Resources;
 using System.Text;
 using System.Collections.ObjectModel;
-using AnEoT.Tools.VolumeCreator.Models.Resources;
+using AnEoT.Tools.Shared;
+using AnEoT.Tools.Shared.Models;
 
 namespace AnEoT.Tools.VolumeCreator.ViewModels;
 
@@ -125,7 +124,7 @@ public sealed partial class MarkdownEditViewModel : ObservableObject
         {
             (FrontMatter frontMatter, PredefinedCategory? predefinedCategory) = dialog.Result;
             MarkdownWrapper.CategoryInIndexPage = predefinedCategory;
-            string yamlHeader = GetYamlFrontMatterString(frontMatter);
+            string yamlHeader = MarkdownHelper.GetYamlHeaderString(frontMatter);
 
             int orderValueIndex = yamlHeader.IndexOf("order:");
             if (orderValueIndex != -1)
@@ -312,22 +311,5 @@ public sealed partial class MarkdownEditViewModel : ObservableObject
         }
 
         return fileNodes;
-    }
-
-    private static string GetYamlFrontMatterString(FrontMatter frontMatter)
-    {
-        ISerializer serializer = new SerializerBuilder()
-                        .WithIndentedSequences()
-                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                        .Build();
-        string yamlString = serializer.Serialize(frontMatter).Trim();
-
-        StringBuilder stringBuilder = new(200);
-        stringBuilder.AppendLine("---");
-        stringBuilder.AppendLine(yamlString);
-        stringBuilder.AppendLine("---");
-        stringBuilder.AppendLine();
-
-        return stringBuilder.ToString();
     }
 }

--- a/src/AnEoT.Tools.VolumeCreator/ViewModels/MarkdownEditViewModel.cs
+++ b/src/AnEoT.Tools.VolumeCreator/ViewModels/MarkdownEditViewModel.cs
@@ -14,7 +14,7 @@ public sealed partial class MarkdownEditViewModel : ObservableObject
 {
     public MarkdownWrapper MarkdownWrapper { get; }
     public ObservableCollection<AssetNode> Assets { get; }
-    public IVoulmeResourcesHelper ResourcesHelper { get; }
+    public IVolumeResourcesHelper ResourcesHelper { get; }
     public Dictionary<string, FileNode> MarkdownImageUriToFileMapping { get; } = new(10);
 
     private readonly MarkdownEditPage view;
@@ -24,7 +24,7 @@ public sealed partial class MarkdownEditViewModel : ObservableObject
     [ObservableProperty]
     private string articleQuote = string.Empty;
 
-    public MarkdownEditViewModel(MarkdownWrapper wrapper, MarkdownEditPage viewPage, ObservableCollection<AssetNode> assets, IVoulmeResourcesHelper resourcesHelper)
+    public MarkdownEditViewModel(MarkdownWrapper wrapper, MarkdownEditPage viewPage, ObservableCollection<AssetNode> assets, IVolumeResourcesHelper resourcesHelper)
     {
         markdownString = wrapper.Markdown;
         view = viewPage;

--- a/src/AnEoT.Tools.VolumeCreator/Views/ContentPage.xaml
+++ b/src/AnEoT.Tools.VolumeCreator/Views/ContentPage.xaml
@@ -222,7 +222,7 @@
                 <AppBarButton.Flyout>
                     <Flyout>
                         <StackPanel Spacing="5">
-                            <TextBlock FontWeight="SemiLight" Text="AnEoT Volume Creator" />
+                            <TextBlock FontWeight="SemiLight" Text="{x:Bind app:App.AppName}" />
                             <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}">
                                 <Run Text="版本：" />
                                 <Run Text="{x:Bind app:App.AppVersion}" />

--- a/src/AnEoT.Tools.VolumeCreator/Views/MainWindow.xaml
+++ b/src/AnEoT.Tools.VolumeCreator/Views/MainWindow.xaml
@@ -24,7 +24,7 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Top"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="AnEoT Volume Creator" />
+            Text="{x:Bind local:App.AppName}" />
 
         <Frame
             x:Name="MainFrame"

--- a/src/AnEoT.Tools.VolumeCreator/Views/MarkdownEditPage.xaml.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Views/MarkdownEditPage.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class MarkdownEditPage : Page
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (e.Parameter is ValueTuple<MarkdownWrapper, ObservableCollection<AssetNode>, IVoulmeResourcesHelper> tuple)
+        if (e.Parameter is ValueTuple<MarkdownWrapper, ObservableCollection<AssetNode>, IVolumeResourcesHelper> tuple)
         {
             ViewModel = new MarkdownEditViewModel(tuple.Item1, this, tuple.Item2, tuple.Item3);
         }

--- a/src/AnEoT.Tools.VolumeCreator/Views/MarkdownEditWindow.xaml.cs
+++ b/src/AnEoT.Tools.VolumeCreator/Views/MarkdownEditWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace AnEoT.Tools.VolumeCreator.Views;
 /// </summary>
 public sealed partial class MarkdownEditWindow : WindowEx
 {
-    public (MarkdownWrapper? Markdown, ObservableCollection<AssetNode> Assets, IVoulmeResourcesHelper ResourceHelper) Model { get; set; }
+    public (MarkdownWrapper? Markdown, ObservableCollection<AssetNode> Assets, IVolumeResourcesHelper ResourceHelper) Model { get; set; }
 
     public MarkdownEditWindow()
     {

--- a/src/AnEoT.Tools.WordToMarkdown/AnEoT.Tools.WordToMarkdown.csproj
+++ b/src/AnEoT.Tools.WordToMarkdown/AnEoT.Tools.WordToMarkdown.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
     <PackageReference Include="MdXaml" Version="1.27.0" />
     <PackageReference Include="MdXaml.Html" Version="1.27.0" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- 更新到 .NET 9
- 将与 Front Matter 有关的方法提取到模型与 MarkdownHelper 中
- 将一些与 WinRT 接口有关的类标记为 `partial`，以使源代码生成器在生成时生成其封送代码
- 将 `ImageListNodeType` 更名为 `AssetNodeType`
- 为一些方法添加 NativeAOT 批注，为支持 NativeAOT 做准备
- 更正 `IVolumeResourcesHelper` 接口的笔误
- 更新各依赖项
- 修复项目包在解析出错时，未能正确清理资源的问题 
- 添加调试应用清单
- 简化项目文件